### PR TITLE
singular -> plural

### DIFF
--- a/index.html
+++ b/index.html
@@ -515,7 +515,7 @@ table.simple {
       <p>As [<cite><a class="bibref" href="#bib-Microformats2">Microformats2</a></cite>] has a relatively small ruleset for parsing
         HTML documents into a data structure, Micropub similarly defines a small set of
         rules to interpret HTTP POST and GET requests as Micropub commands.
-        Where Microformats does not require changing the parsing rules to
+        Where Microformats do not require changing the parsing rules to
         introduce new properties of an object such as an [<cite><a class="bibref" href="#bib-h-entry">h-entry</a></cite>], Micropub
         similarly does not require changing parsing rules to interpret requests
         that may correspond to different post types, such as posting videos vs


### PR DESCRIPTION
i guess you could argue that "Microformats" is a name and thus singular, but in terms of reading flow, plural works better here, i think.
