### PR TITLE
Add Micropublish's new support for q=source with properties.

### DIFF
--- a/implementation-reports/micropublish.md
+++ b/implementation-reports/micropublish.md
@@ -56,7 +56,7 @@ Developer(s): [Barry Frost](https://barryfrost.com)
  * [x] Looks in the response for syndication targets
 * [ ] Queries the Micropub endpoint with `q=syndicate-to`
 * [x] Queries the Micropub endpoint for a post's source content without specifying a list of properties
-* [ ] Queries the Micropub endpoint for a post's source content looking only for specific properties
+* [x] Queries the Micropub endpoint for a post's source content looking only for specific properties
 
 ## Extensions
 


### PR DESCRIPTION
@aaronpk This adds Micropublish's support for q=source with properties.