### PR TITLE
Fix: Align HTTP status code for `insufficient_scope` with RFC6750

### DIFF
--- a/draft/source/index.html
+++ b/draft/source/index.html
@@ -1009,8 +1009,8 @@ Content-type: application/json
 
         <p><ul>
           <li>HTTP 403: <code>"error":"forbidden"</code> - The authenticated user does not have permission to perform this request.</li>
+          <li>HTTP 403: <code>"error":"insufficient_scope"</code> - The scope of this token does not meet the requirements for this request. The client may wish to re-authorize the user to obtain the necessary scope. The response MAY include the <code>"scope"</code> attribute with the scope necessary to successfully perform this request.</li>
           <li>HTTP 401: <code>"error":"unauthorized"</code> - No access token was provided in the request. Note that this is different from the HTTP 403 response, as the 403 response should only be used when an access token is provided and the user does not have permission to perform the request.</li>
-          <li>HTTP 401: <code>"error":"insufficient_scope"</code> - The scope of this token does not meet the requirements for this request. The client may wish to re-authorize the user to obtain the necessary scope. The response MAY include the <code>"scope"</code> attribute with the scope necessary to successfully perform this request.</li>
           <li>HTTP 400: <code>"error":"invalid_request"</code> - The request is missing a required parameter, or there was a problem with a value of one of the parameters</li>
         </ul></p>
 


### PR DESCRIPTION
As I noted in [chat], the Micropub spec doesn't align with the OAuth2
spec regarding the `insufficient_scope` error message. We should align
with [RFC6750] to ensure that implementers can rely on out-of-the-box
OAuth2 implementations.

Additionally, move the element up, to group it with the other 403 error
code, for readability.

[chat]: https://chat.indieweb.org/dev/2020-04-11/1586648523426500
[RFC6750]: https://tools.ietf.org/html/rfc6750#section-3.1